### PR TITLE
Update Compose instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ node_modules/
 .idea/
 .vscode/
 .pnpm-store/
+node-compile-cache/

--- a/README.md
+++ b/README.md
@@ -71,10 +71,10 @@ docker run -p 3000:3000 -e DATABASE_URL=your_database_url jamc-app
 For orchestrating multiple services:
 
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 
-This will start the application and any required services (database, etc.) defined in the docker-compose.yml file.
+This will start the application and any required services (database, etc.) defined in the compose.yaml file.
 
 ## Learn More
 


### PR DESCRIPTION
## Summary
- note docker compile cache in gitignore
- update README to use `compose.yaml` with `docker compose`

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_683faa0680e8832bb2045aaea6e39035